### PR TITLE
fix: resolve localStorage quota error for large permutation sets; add rename loading state

### DIFF
--- a/project/bldr/src/components/Sidebar.tsx
+++ b/project/bldr/src/components/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
   Check,
   ChevronDown,
   Edit2,
+  Loader2,
   Menu,
   MoreHorizontal,
   Sidebar as SidebarIcon,
@@ -190,6 +191,9 @@ export function Sidebar() {
   // Input value for renaming a schedule
   const [renameValue, setRenameValue] = useState("");
 
+  // True while the rename API call is in-flight
+  const [isRenamingSaving, setIsRenamingSaving] = useState(false);
+
   // Track which schedule is being deleted (for AlertDialog)
   const [deletingScheduleId, setDeletingScheduleId] = useState<string | null>(
     null,
@@ -338,6 +342,7 @@ export function Sidebar() {
       return;
     }
 
+    setIsRenamingSaving(true);
     try {
       const res = await fetch("/api/renameSchedule", {
         method: "POST",
@@ -378,6 +383,7 @@ export function Sidebar() {
         },
       );
     } finally {
+      setIsRenamingSaving(false);
       setRenamingScheduleId(null);
       setRenameValue("");
     }
@@ -641,27 +647,34 @@ export function Sidebar() {
                                           }
                                         }}
                                         autoFocus
-                                        className="h-8 text-xs border-[#404040] bg-[#2a2a2a] flex-1"
+                                        disabled={isRenamingSaving}
+                                        className="h-8 text-xs border-[#404040] bg-[#2a2a2a] flex-1 disabled:opacity-50"
                                       />
-                                      <button
-                                        type="button"
-                                        onClick={() =>
-                                          handleRenameSchedule(
-                                            schedule.id,
-                                            renameValue,
-                                          )
-                                        }
-                                        className="p-1.5 hover:bg-[#555] rounded transition cursor-pointer"
-                                      >
-                                        <Check className="h-4 w-4 text-green-500" />
-                                      </button>
-                                      <button
-                                        type="button"
-                                        onClick={cancelRenaming}
-                                        className="p-1.5 hover:bg-[#555] rounded transition cursor-pointer"
-                                      >
-                                        <X className="h-4 w-4 text-red-500" />
-                                      </button>
+                                      {isRenamingSaving ? (
+                                        <Loader2 className="h-4 w-4 text-gray-400 animate-spin shrink-0" />
+                                      ) : (
+                                        <>
+                                          <button
+                                            type="button"
+                                            onClick={() =>
+                                              handleRenameSchedule(
+                                                schedule.id,
+                                                renameValue,
+                                              )
+                                            }
+                                            className="p-1.5 hover:bg-[#555] rounded transition cursor-pointer"
+                                          >
+                                            <Check className="h-4 w-4 text-green-500" />
+                                          </button>
+                                          <button
+                                            type="button"
+                                            onClick={cancelRenaming}
+                                            className="p-1.5 hover:bg-[#555] rounded transition cursor-pointer"
+                                          >
+                                            <X className="h-4 w-4 text-red-500" />
+                                          </button>
+                                        </>
+                                      )}
                                     </div>
                                   ) : (
                                     <>
@@ -876,27 +889,34 @@ export function Sidebar() {
                                               }
                                             }}
                                             autoFocus
-                                            className="h-7 text-xs border-[#404040] bg-[#2a2a2a] flex-1"
+                                            disabled={isRenamingSaving}
+                                            className="h-7 text-xs border-[#404040] bg-[#2a2a2a] flex-1 disabled:opacity-50"
                                           />
-                                          <button
-                                            type="button"
-                                            onClick={() =>
-                                              handleRenameSchedule(
-                                                schedule.id,
-                                                renameValue,
-                                              )
-                                            }
-                                            className="p-1 hover:bg-[#444] rounded transition cursor-pointer"
-                                          >
-                                            <Check className="h-4 w-4 text-green-500" />
-                                          </button>
-                                          <button
-                                            type="button"
-                                            onClick={cancelRenaming}
-                                            className="p-1 hover:bg-[#444] rounded transition cursor-pointer"
-                                          >
-                                            <X className="h-4 w-4 text-red-500" />
-                                          </button>
+                                          {isRenamingSaving ? (
+                                            <Loader2 className="h-4 w-4 text-gray-400 animate-spin shrink-0" />
+                                          ) : (
+                                            <>
+                                              <button
+                                                type="button"
+                                                onClick={() =>
+                                                  handleRenameSchedule(
+                                                    schedule.id,
+                                                    renameValue,
+                                                  )
+                                                }
+                                                className="p-1 hover:bg-[#444] rounded transition cursor-pointer"
+                                              >
+                                                <Check className="h-4 w-4 text-green-500" />
+                                              </button>
+                                              <button
+                                                type="button"
+                                                onClick={cancelRenaming}
+                                                className="p-1 hover:bg-[#444] rounded transition cursor-pointer"
+                                              >
+                                                <X className="h-4 w-4 text-red-500" />
+                                              </button>
+                                            </>
+                                          )}
                                         </div>
                                       ) : (
                                         <>

--- a/project/bldr/src/lib/permutationUtils.ts
+++ b/project/bldr/src/lib/permutationUtils.ts
@@ -245,33 +245,33 @@ export function createDraftHash(draftSchedule: ClassSection[]): string {
 }
 
 /**
- * Saves permutations to localStorage
- * @param permutations - Array of valid schedule permutations
+ * Saves permutation navigation state to localStorage.
+ * The permutations array itself is not persisted — it can exceed the browser's
+ * ~5 MB quota for large schedules and is always regenerable from the draft.
+ * @param permutations - Unused; kept in signature so call-sites need no changes
  * @param currentIndex - Current permutation index
  * @param draftHash - Hash of the draft that generated these permutations
  */
 export function savePermutationsToStorage(
-  permutations: ClassSection[][],
+  _permutations: ClassSection[][],
   currentIndex: number,
   draftHash: string
 ): void {
   if (typeof window === "undefined") return;
 
   try {
-    localStorage.setItem(
-      PERMUTATIONS_STORAGE_KEY,
-      JSON.stringify(permutations)
-    );
     localStorage.setItem(PERMUTATION_INDEX_STORAGE_KEY, String(currentIndex));
     localStorage.setItem(PERMUTATION_DRAFT_HASH_KEY, draftHash);
   } catch (e) {
-    console.error("Failed to save permutations to localStorage:", e);
+    console.error("Failed to save permutation state to localStorage:", e);
   }
 }
 
 /**
- * Loads permutations from localStorage
- * @returns Object with permutations, currentIndex, and draftHash, or null if not found
+ * Loads permutation navigation state from localStorage.
+ * Returns an empty permutations array — permutations are regenerated on mount
+ * from the persisted draft schedule via generateSchedulePermutations.
+ * @returns Object with empty permutations, currentIndex, and draftHash, or null if not found
  */
 export function loadPermutationsFromStorage(): {
   permutations: ClassSection[][];
@@ -281,25 +281,25 @@ export function loadPermutationsFromStorage(): {
   if (typeof window === "undefined") return null;
 
   try {
-    const permutationsStr = localStorage.getItem(PERMUTATIONS_STORAGE_KEY);
     const indexStr = localStorage.getItem(PERMUTATION_INDEX_STORAGE_KEY);
     const draftHash = localStorage.getItem(PERMUTATION_DRAFT_HASH_KEY);
 
-    if (!permutationsStr || !draftHash) return null;
+    if (!draftHash) return null;
 
     return {
-      permutations: JSON.parse(permutationsStr),
+      permutations: [],
       currentIndex: indexStr ? parseInt(indexStr, 10) : 0,
       draftHash,
     };
   } catch (e) {
-    console.error("Failed to load permutations from localStorage:", e);
+    console.error("Failed to load permutation state from localStorage:", e);
     return null;
   }
 }
 
 /**
- * Clears permutations from localStorage
+ * Clears permutation state from localStorage.
+ * Also removes the legacy PERMUTATIONS_STORAGE_KEY in case stale data exists.
  */
 export function clearPermutationsFromStorage(): void {
   if (typeof window === "undefined") return;


### PR DESCRIPTION
## Summary

- Stops persisting the full permutations array to localStorage — for schedules with 3914+ permutations the serialized `ClassSection[][]` exceeded the browser's ~5 MB quota and crashed the page. Permutations are a derived value regenerable from the persisted draft schedule; only the current index and draft hash are now stored.
- Adds a loading state (spinning `Loader2` icon, disabled input) to the schedule rename flow in the sidebar while the API call is in-flight, on both mobile and desktop.

## Test plan

- [ ] Add 4+ classes with many sections and confirm no localStorage quota error is thrown
- [ ] Navigate with Next/Prev permutation — confirm schedule changes with no latency regression
- [ ] Refresh page — confirm draft is restored and permutations regenerate without error
- [ ] Trigger a schedule rename and confirm the spinner appears while saving, then resolves on success or error
- [ ] Confirm the X (cancel) button is hidden during save so the user can't cancel mid-flight

Closes #50