### PR TITLE
fix: purge stale permutations array from localStorage to fully resolve quota error

### DIFF
--- a/project/bldr/src/lib/permutationUtils.ts
+++ b/project/bldr/src/lib/permutationUtils.ts
@@ -260,6 +260,9 @@ export function savePermutationsToStorage(
   if (typeof window === "undefined") return;
 
   try {
+    // Purge any stale full-array data left by older versions before writing,
+    // so a filled quota doesn't block writing the small index/hash values.
+    localStorage.removeItem(PERMUTATIONS_STORAGE_KEY);
     localStorage.setItem(PERMUTATION_INDEX_STORAGE_KEY, String(currentIndex));
     localStorage.setItem(PERMUTATION_DRAFT_HASH_KEY, draftHash);
   } catch (e) {
@@ -281,6 +284,8 @@ export function loadPermutationsFromStorage(): {
   if (typeof window === "undefined") return null;
 
   try {
+    // Eagerly purge stale full-array data on mount so it doesn't fill the quota.
+    localStorage.removeItem(PERMUTATIONS_STORAGE_KEY);
     const indexStr = localStorage.getItem(PERMUTATION_INDEX_STORAGE_KEY);
     const draftHash = localStorage.getItem(PERMUTATION_DRAFT_HASH_KEY);
 


### PR DESCRIPTION
## Summary

The previous fix stopped writing the full `ClassSection[][]` array to localStorage, but didn't remove the old `schedulePermutations` key that may already be stored from before the fix. That stale entry alone can consume the entire ~5 MB quota, causing `QuotaExceededError` even when only writing tiny strings (the index and draft hash).

This fix adds `localStorage.removeItem(PERMUTATIONS_STORAGE_KEY)` in two places:
- **`loadPermutationsFromStorage`** — called once on mount, eagerly purges any stale array data before any writes happen
- **`savePermutationsToStorage`** — safety net, removes the key before writing the index/hash on every save

## Test plan

- [x] Open the app with old `schedulePermutations` data still in localStorage (DevTools → Application → Storage)
- [x] Add a combination of classes that yields 22k+ permutations
- [x] Confirm no `QuotaExceededError` is thrown in the console
- [x] Confirm permutation navigation still works normally

Closes #50