### PR TITLE
feat: schedule sharing via public read-only link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@
 - Share schedules with a public read-only link
 - Real-time schedule updates and persistence
 
+### 🔗 Schedule Sharing
+- Turn sharing on or off for any saved schedule from the sidebar
+- Copy a public URL to send your schedule to classmates, advisors, or friends
+- Shared links open a read-only calendar page so viewers can inspect classes without editing
+
 ### 📊 Class Details
 - View available sections for each course
 - Real-time seat availability with color indicators:
@@ -129,4 +134,3 @@ The application follows a modern full-stack architecture:
 **Built with ❤️ by KU students for all students**
 
 </div>
-

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - Create multiple schedules for different semester scenarios
 - Save, rename, and delete schedules
 - Sidebar navigation for quick schedule switching
+- Share schedules with a public read-only link
 - Real-time schedule updates and persistence
 
 ### 📊 Class Details

--- a/project/bldr/Supabase auth overview.md
+++ b/project/bldr/Supabase auth overview.md
@@ -34,6 +34,7 @@ This project uses Supabase to handle user authentication in a modern, secure, an
 ## 5. **Database Security (Row Level Security)**
 - All user data in the database is protected with Row Level Security (RLS).
 - Only the authenticated user can access or modify their own data.
+- Public schedule links expose only schedules that have been explicitly marked public.
 - RLS policies are enforced automatically by Supabase.
 
 ---

--- a/project/bldr/src/app/api/getUserSchedules/route.ts
+++ b/project/bldr/src/app/api/getUserSchedules/route.ts
@@ -10,53 +10,18 @@
  */
 
 import type { NextRequest } from "next/server";
+import { type ClassDetailRow, formatClassSection } from "@/lib/scheduleFormat";
 import { supabase } from "../../lib/supabaseClient";
-
-type SearchClassMeta = {
-  dept: string;
-  code: string;
-  title: string | null;
-};
-
-type ClassDetailRow = {
-  uuid: string;
-  classid: number;
-  days: string | null;
-  starttime: string | null;
-  endtime: string | null;
-  component: string | null;
-  instructor: string | null;
-  location: string | null;
-  room: string | null;
-  availseats: number | null;
-  minhours: number | null;
-  maxhours: number | null;
-  searchclass: SearchClassMeta | SearchClassMeta[] | null;
-};
 
 type ScheduleRow = {
   scheduleid: string;
   schedulename: string;
   semester: string;
   year: number;
+  is_public: boolean | null;
   createdat: Date | string | null;
   lastedited: Date | string | null;
 };
-
-function pickSearchClassMeta(
-  value: SearchClassMeta | SearchClassMeta[] | null,
-): SearchClassMeta {
-  if (Array.isArray(value)) {
-    return value[0] ?? { dept: "", code: "", title: "" };
-  }
-  return value ?? { dept: "", code: "", title: "" };
-}
-
-function deriveCreditHours(minhours: number | null, maxhours: number | null) {
-  if (typeof maxhours === "number") return maxhours;
-  if (typeof minhours === "number") return minhours;
-  return undefined;
-}
 
 export async function GET(req: NextRequest) {
   try {
@@ -104,7 +69,9 @@ export async function GET(req: NextRequest) {
 
     const { data: schedules, error: schedulesError } = await supabase
       .from("allschedules")
-      .select("scheduleid, schedulename, semester, year, createdat, lastedited")
+      .select(
+        "scheduleid, schedulename, semester, year, is_public, createdat, lastedited",
+      )
       .in("scheduleid", scheduleIds)
       .order("createdat", { ascending: false });
 
@@ -182,31 +149,7 @@ export async function GET(req: NextRequest) {
         const formattedClasses = classIds
           .map((uuid) => classByUuid.get(uuid))
           .filter(Boolean)
-          .map((cls) => {
-            const section = cls as ClassDetailRow;
-            const course = pickSearchClassMeta(section.searchclass);
-            return {
-              uuid: section.uuid,
-              classID: section.classid?.toString() || "",
-              dept: course.dept,
-              code: course.code,
-              title: course.title ?? `${course.dept} ${course.code}`,
-              days: section.days || "",
-              starttime: section.starttime || "",
-              endtime: section.endtime || "",
-              component: section.component || "",
-              instructor: section.instructor || undefined,
-              seats_available: section.availseats ?? 0,
-              minhours: section.minhours ?? undefined,
-              maxhours: section.maxhours ?? undefined,
-              credithours: deriveCreditHours(
-                section.minhours,
-                section.maxhours,
-              ),
-              location: section.location || undefined,
-              room: section.room || undefined,
-            };
-          });
+          .map((cls) => formatClassSection(cls as ClassDetailRow));
 
         return {
           id: schedule.scheduleid,
@@ -215,6 +158,7 @@ export async function GET(req: NextRequest) {
           year: schedule.year,
           classes: formattedClasses,
           isActive: activeByScheduleId.get(schedule.scheduleid) ?? false,
+          isPublic: Boolean(schedule.is_public),
           createdAt: schedule.createdat,
           updatedAt: schedule.lastedited,
         };

--- a/project/bldr/src/app/api/publicSchedule/[scheduleId]/route.ts
+++ b/project/bldr/src/app/api/publicSchedule/[scheduleId]/route.ts
@@ -1,0 +1,156 @@
+/**
+ * API Route: /api/publicSchedule/[scheduleId]
+ *
+ * Fetches a public read-only schedule using the anonymous Supabase key.
+ * Existing RLS policies are preserved and remain the source of truth.
+ *
+ * @method GET
+ * @returns { schedule: Schedule }
+ */
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+import { type ClassDetailRow, formatClassSection } from "@/lib/scheduleFormat";
+import type { ClassSection } from "@/types";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type ScheduleRow = {
+  scheduleid: string;
+  schedulename: string;
+  semester: string;
+  year: number;
+  createdat: Date | string | null;
+  lastedited: Date | string | null;
+};
+
+type ScheduleClassRow = {
+  class_uuid: string;
+};
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ scheduleId: string }> },
+) {
+  try {
+    const { scheduleId } = await context.params;
+    if (!UUID_PATTERN.test(scheduleId)) {
+      return NextResponse.json(
+        { error: "Schedule not found" },
+        { status: 404 },
+      );
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return NextResponse.json(
+        { error: "Supabase environment variables are not configured" },
+        { status: 500 },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+
+    const { data: schedule, error: scheduleError } = await supabase
+      .from("allschedules")
+      .select("scheduleid, schedulename, semester, year, createdat, lastedited")
+      .eq("scheduleid", scheduleId)
+      .eq("is_public", true)
+      .maybeSingle();
+
+    if (scheduleError) {
+      console.error("[publicSchedule] Error fetching schedule:", scheduleError);
+      return NextResponse.json(
+        { error: "Failed to fetch schedule" },
+        { status: 500 },
+      );
+    }
+
+    if (!schedule) {
+      return NextResponse.json(
+        { error: "Schedule not found" },
+        { status: 404 },
+      );
+    }
+
+    const { data: scheduleClasses, error: scheduleClassesError } =
+      await supabase
+        .from("schedule_classes")
+        .select("class_uuid")
+        .eq("scheduleid", scheduleId)
+        .order("added_at", { ascending: true });
+
+    if (scheduleClassesError) {
+      console.error(
+        "[publicSchedule] Error fetching schedule classes:",
+        scheduleClassesError,
+      );
+      return NextResponse.json(
+        { error: "Failed to fetch schedule classes" },
+        { status: 500 },
+      );
+    }
+
+    const classUuids = (scheduleClasses as ScheduleClassRow[] | null)?.map(
+      (row) => row.class_uuid,
+    );
+
+    let formattedClasses: ClassSection[] = [];
+    if (classUuids && classUuids.length > 0) {
+      const { data: classRows, error: classDetailsError } = await supabase
+        .from("allclasses")
+        .select(
+          "uuid,classid,days,starttime,endtime,component,instructor,location,room,availseats,minhours,maxhours,searchclass:searchclasses!allclasses_searchclass_fkey(dept,code,title)",
+        )
+        .in("uuid", classUuids);
+
+      if (classDetailsError) {
+        console.error(
+          "[publicSchedule] Error fetching class details:",
+          classDetailsError,
+        );
+        return NextResponse.json(
+          { error: "Failed to fetch class details" },
+          { status: 500 },
+        );
+      }
+
+      const classByUuid = new Map<string, ClassDetailRow>();
+      for (const row of (classRows ?? []) as ClassDetailRow[]) {
+        classByUuid.set(row.uuid, row);
+      }
+
+      formattedClasses = classUuids
+        .map((uuid) => classByUuid.get(uuid))
+        .filter(Boolean)
+        .map((row) => formatClassSection(row as ClassDetailRow));
+    }
+
+    const row = schedule as ScheduleRow;
+    return NextResponse.json({
+      schedule: {
+        id: row.scheduleid,
+        name: row.schedulename,
+        semester: row.semester,
+        year: row.year,
+        classes: formattedClasses,
+        isPublic: true,
+        createdAt: row.createdat,
+        updatedAt: row.lastedited,
+      },
+    });
+  } catch (error) {
+    console.error("[publicSchedule] Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/project/bldr/src/app/api/shareSchedule/route.ts
+++ b/project/bldr/src/app/api/shareSchedule/route.ts
@@ -1,0 +1,86 @@
+/**
+ * API Route: /api/shareSchedule
+ *
+ * Toggles public sharing for a schedule owned by the authenticated user.
+ *
+ * @method PATCH
+ * @requires Authorization header with Bearer token
+ * @body { scheduleId: string, isPublic: boolean }
+ * @returns { isPublic: boolean }
+ */
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { supabase } from "../../lib/supabaseClient";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader) {
+      return NextResponse.json(
+        { error: "No authorization header" },
+        { status: 401 },
+      );
+    }
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser(authHeader.replace("Bearer ", ""));
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { scheduleId, isPublic } = body;
+
+    if (
+      typeof scheduleId !== "string" ||
+      !UUID_PATTERN.test(scheduleId) ||
+      typeof isPublic !== "boolean"
+    ) {
+      return NextResponse.json(
+        { error: "Invalid scheduleId or isPublic" },
+        { status: 400 },
+      );
+    }
+
+    const { data: ownership, error: ownershipError } = await supabase
+      .from("userschedule")
+      .select("scheduleid")
+      .eq("auth_user_id", user.id)
+      .eq("scheduleid", scheduleId)
+      .single();
+
+    if (ownershipError || !ownership) {
+      return NextResponse.json(
+        { error: "Schedule not found or unauthorized" },
+        { status: 404 },
+      );
+    }
+
+    const { error: updateError } = await supabase
+      .from("allschedules")
+      .update({ is_public: isPublic })
+      .eq("scheduleid", scheduleId);
+
+    if (updateError) {
+      console.error("[shareSchedule] Error updating share state:", updateError);
+      return NextResponse.json(
+        { error: "Failed to update sharing" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ isPublic });
+  } catch (error) {
+    console.error("[shareSchedule] Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/project/bldr/src/app/builder/page.tsx
+++ b/project/bldr/src/app/builder/page.tsx
@@ -220,6 +220,10 @@ export default function Builder() {
         year: draftYear,
         classes: draftSchedule,
         isActive: true,
+        isPublic:
+          existingScheduleId && activeSchedule?.id === existingScheduleId
+            ? (activeSchedule?.isPublic ?? false)
+            : false,
       };
 
       if (existingScheduleId) {
@@ -619,7 +623,10 @@ export default function Builder() {
                     </span>
                   </TabsTrigger>
                 </TabsList>
-                <TabsContent value={activeTab} className="mt-0 min-h-0 overflow-hidden">
+                <TabsContent
+                  value={activeTab}
+                  className="mt-0 min-h-0 overflow-hidden"
+                >
                   <AnimatePresence mode="wait" initial={false}>
                     <motion.div
                       key={activeTab}

--- a/project/bldr/src/app/s/[scheduleId]/page.tsx
+++ b/project/bldr/src/app/s/[scheduleId]/page.tsx
@@ -1,0 +1,88 @@
+import { headers } from "next/headers";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import CalendarEditor from "@/components/CalendarEditor";
+import { Button } from "@/components/ui/button";
+import type { Schedule } from "@/types";
+
+type PublicSchedulePageProps = {
+  params: Promise<{
+    scheduleId: string;
+  }>;
+};
+
+async function getPublicSchedule(scheduleId: string) {
+  const headerStore = await headers();
+  const host = headerStore.get("host");
+
+  if (!host) {
+    return null;
+  }
+
+  const protocol =
+    headerStore.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") ? "http" : "https");
+  const response = await fetch(
+    `${protocol}://${host}/api/publicSchedule/${encodeURIComponent(
+      scheduleId,
+    )}`,
+    { cache: "no-store" },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error("Failed to load public schedule");
+  }
+
+  const data = (await response.json()) as { schedule?: Schedule };
+  return data.schedule ?? null;
+}
+
+export default async function PublicSchedulePage({
+  params,
+}: PublicSchedulePageProps) {
+  const { scheduleId } = await params;
+  const schedule = await getPublicSchedule(scheduleId);
+
+  if (!schedule) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-[#080808] text-white">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-3 py-4 sm:px-5 lg:px-8">
+        <header className="flex flex-col gap-3 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0">
+            <Link href="/" className="font-dmsans text-lg font-bold">
+              <span className="text-white">b</span>
+              <span className="text-red-500">l</span>
+              <span className="text-blue-600">d</span>
+              <span className="text-yellow-300">r</span>
+            </Link>
+            <h1 className="mt-2 truncate font-figtree text-2xl font-semibold lg:text-3xl">
+              {schedule.name}
+            </h1>
+            <p className="font-inter text-sm text-[#A8A8A8]">
+              {schedule.semester} {schedule.year}
+            </p>
+          </div>
+          <Button asChild className="w-fit font-dmsans">
+            <Link href="/">Build your own schedule</Link>
+          </Button>
+        </header>
+
+        <section className="min-h-[520px]">
+          <CalendarEditor
+            classes={schedule.classes}
+            emptyMessage="This shared schedule does not have any classes yet."
+            readOnly
+            scheduleName={schedule.name}
+          />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/project/bldr/src/components/CalendarEditor.tsx
+++ b/project/bldr/src/components/CalendarEditor.tsx
@@ -34,6 +34,13 @@ import { useScheduleBuilder } from "@/contexts/ScheduleBuilderContext";
 import { calculateDuration, parseDays, timeToDecimal } from "@/lib/timeUtils";
 import type { ClassSection } from "@/types";
 
+type CalendarEditorProps = {
+  classes?: ClassSection[];
+  scheduleName?: string;
+  readOnly?: boolean;
+  emptyMessage?: string;
+};
+
 const toKeyPart = (value: unknown, fallback: string) => {
   const normalized = typeof value === "string" ? value.trim() : "";
   return normalized.length > 0 ? normalized : fallback;
@@ -48,7 +55,12 @@ const toKeyPart = (value: unknown, fallback: string) => {
  *
  * returns {JSX.Element} The calendar grid with positioned class blocks
  */
-const CalendarEditor = () => {
+const CalendarEditor = ({
+  classes,
+  scheduleName,
+  readOnly = false,
+  emptyMessage = "Add a class section to see it here!",
+}: CalendarEditorProps = {}) => {
   // Access the draft schedule data from the ScheduleBuilder context
   const {
     draftSchedule,
@@ -56,6 +68,11 @@ const CalendarEditor = () => {
     removeClassFromDraft,
     togglePinSection,
   } = useScheduleBuilder();
+  const calendarClasses = classes ?? draftSchedule;
+  const calendarName = scheduleName ?? draftScheduleName;
+  const shouldShowCalendar = readOnly
+    ? Boolean(calendarName)
+    : Boolean(calendarName && calendarClasses.length > 0);
 
   // Days of the week to display as column headers
   const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
@@ -68,6 +85,8 @@ const CalendarEditor = () => {
    * @param cls - The class section to remove
    */
   const handleRemoveSection = (cls: ClassSection) => {
+    if (readOnly) return;
+
     const index = draftSchedule.findIndex(
       (item: ClassSection) => item.uuid === cls.uuid,
     );
@@ -81,6 +100,8 @@ const CalendarEditor = () => {
    * @param cls - The class section to toggle pin
    */
   const handleTogglePin = (cls: ClassSection) => {
+    if (readOnly) return;
+
     togglePinSection(cls.uuid);
   };
 
@@ -88,7 +109,7 @@ const CalendarEditor = () => {
     <div className="relative grid grid-rows-1 bg-[#2c2c2c] border-2 border-[#404040] rounded-[10px] text-white px-2 py-2 w-full aspect-square md:aspect-auto md:h-full md:min-h-[500px]">
       <div className="w-full h-full overflow-hidden">
         <AnimatePresence mode="wait">
-          {draftScheduleName && draftSchedule.length > 0 ? (
+          {shouldShowCalendar ? (
             <motion.div
               key="calendar"
               initial={{ opacity: 0 }}
@@ -129,7 +150,7 @@ const CalendarEditor = () => {
                         <td key={day} className="relative align-top w-[18%]">
                           <div className="absolute top-[50%] translate-y-[-50%] w-full border-t border-dashed border-[#424242] z-0" />
 
-                          {draftSchedule
+                          {calendarClasses
                             .filter((cls: ClassSection) => {
                               const classDays = parseDays(cls.days || "");
                               const startTime = timeToDecimal(
@@ -210,13 +231,15 @@ const CalendarEditor = () => {
                                               backgroundColor:
                                                 colors[colorIndex],
                                             }}
-                                            onDoubleClick={() =>
-                                              handleTogglePin(cls)
+                                            onDoubleClick={
+                                              readOnly
+                                                ? undefined
+                                                : () => handleTogglePin(cls)
                                             }
                                           >
                                             <div className="flex items-center justify-between font-bold text-[9px] lg:text-[10px] xl:text-xs font-dmsans truncate w-full">
                                               <span className="flex items-center gap-0.5 truncate">
-                                                {cls.pinned && (
+                                                {!readOnly && cls.pinned && (
                                                   <Pin className="h-2.5 w-2.5 lg:h-3 lg:w-3 text-amber-600 shrink-0" />
                                                 )}
                                                 <span className="truncate">
@@ -288,7 +311,7 @@ const CalendarEditor = () => {
                                               </div>
 
                                               <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 border-t border-white/10 pt-2.5 text-[11px] leading-5">
-                                                {cls.pinned && (
+                                                {!readOnly && cls.pinned && (
                                                   <p className="min-w-0">
                                                     <span className="font-semibold text-slate-300">
                                                       Status:
@@ -308,14 +331,20 @@ const CalendarEditor = () => {
                                                     </span>
                                                   </p>
                                                 )}
-                                                <p className="col-span-2 min-w-0 text-slate-400">
-                                                  <span className="font-semibold text-slate-300">
-                                                    Actions:
-                                                  </span>{" "}
-                                                  Double-click to{" "}
-                                                  {cls.pinned ? "unpin" : "pin"}
-                                                  {"; right-click for options"}
-                                                </p>
+                                                {!readOnly && (
+                                                  <p className="col-span-2 min-w-0 text-slate-400">
+                                                    <span className="font-semibold text-slate-300">
+                                                      Actions:
+                                                    </span>{" "}
+                                                    Double-click to{" "}
+                                                    {cls.pinned
+                                                      ? "unpin"
+                                                      : "pin"}
+                                                    {
+                                                      "; right-click for options"
+                                                    }
+                                                  </p>
+                                                )}
                                               </div>
                                             </div>
                                           </div>
@@ -323,28 +352,30 @@ const CalendarEditor = () => {
                                       </Tooltip>
                                     </TooltipProvider>
                                   </ContextMenuTrigger>
-                                  <ContextMenuContent className=" bg-[#2a2a2a] border-[#404040]">
-                                    <ContextMenuItem
-                                      className="text-amber-400 font-dmsans focus:bg-[#404040] focus:text-amber-400 cursor-pointer"
-                                      onClick={() => handleTogglePin(cls)}
-                                    >
-                                      {cls.pinned ? (
-                                        <PinOff className="mr-1 h-4 text-amber-400" />
-                                      ) : (
-                                        <Pin className="mr-1 h-4 text-amber-400" />
-                                      )}
-                                      {cls.pinned
-                                        ? "Unpin Section"
-                                        : "Pin Section"}
-                                    </ContextMenuItem>
-                                    <ContextMenuItem
-                                      className="text-destructive font-dmsans focus:bg-[#404040] focus:text-destructive cursor-pointer"
-                                      onClick={() => handleRemoveSection(cls)}
-                                    >
-                                      <Trash2 className="mr-1 h-4 text-destructive" />
-                                      Remove Section
-                                    </ContextMenuItem>
-                                  </ContextMenuContent>
+                                  {!readOnly && (
+                                    <ContextMenuContent className=" bg-[#2a2a2a] border-[#404040]">
+                                      <ContextMenuItem
+                                        className="text-amber-400 font-dmsans focus:bg-[#404040] focus:text-amber-400 cursor-pointer"
+                                        onClick={() => handleTogglePin(cls)}
+                                      >
+                                        {cls.pinned ? (
+                                          <PinOff className="mr-1 h-4 text-amber-400" />
+                                        ) : (
+                                          <Pin className="mr-1 h-4 text-amber-400" />
+                                        )}
+                                        {cls.pinned
+                                          ? "Unpin Section"
+                                          : "Pin Section"}
+                                      </ContextMenuItem>
+                                      <ContextMenuItem
+                                        className="text-destructive font-dmsans focus:bg-[#404040] focus:text-destructive cursor-pointer"
+                                        onClick={() => handleRemoveSection(cls)}
+                                      >
+                                        <Trash2 className="mr-1 h-4 text-destructive" />
+                                        Remove Section
+                                      </ContextMenuItem>
+                                    </ContextMenuContent>
+                                  )}
                                 </ContextMenu>
                               );
                             })}
@@ -357,7 +388,7 @@ const CalendarEditor = () => {
             </motion.div>
           ) : (
             <div className="font-inter flex h-full w-full justify-center items-center m-2 text-center text-xs md:text-sm">
-              Add a class section to see it here!
+              {emptyMessage}
             </div>
           )}
         </AnimatePresence>

--- a/project/bldr/src/components/LandingPage.tsx
+++ b/project/bldr/src/components/LandingPage.tsx
@@ -8,9 +8,9 @@ import {
   FolderKanban,
   Info,
   Search,
+  Share2,
   ShieldCheck,
   Sparkles,
-  TabletSmartphone,
 } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -57,12 +57,12 @@ const featureCards = [
     surface: "from-cyan-500/15 to-cyan-500/5",
   },
   {
-    title: "Responsive, student-friendly UX",
+    title: "Shareable read-only schedules",
     description:
-      "A dark interface, smooth motion, toasts, and responsive layouts keep the builder usable across laptops, tablets, and smaller screens.",
-    icon: TabletSmartphone,
-    accent: "text-violet-300",
-    surface: "from-violet-500/15 to-violet-500/5",
+      "Enable sharing for any saved schedule and copy a public link that opens a read-only calendar view your friends or advisors can review.",
+    icon: Share2,
+    accent: "text-lime-300",
+    surface: "from-lime-500/15 to-lime-500/5",
   },
 ];
 
@@ -88,7 +88,7 @@ const builderSignals = [
   "Real-time course lookup",
   "Seat alerts",
   "Saved schedule variants",
-  "Guest mode",
+  "Shareable schedule links",
 ];
 
 export default function LandingPage() {

--- a/project/bldr/src/components/Sidebar.tsx
+++ b/project/bldr/src/components/Sidebar.tsx
@@ -26,10 +26,13 @@ import {
   AlertCircle,
   Check,
   ChevronDown,
+  Copy,
   Edit2,
+  Link as LinkIcon,
   Loader2,
   Menu,
   MoreHorizontal,
+  Share2,
   Sidebar as SidebarIcon,
   Trash2,
   User,
@@ -66,6 +69,7 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { Spinner } from "./ui/spinner";
+import { Switch } from "./ui/switch";
 
 const sidebarEnterEase = [0.22, 1, 0.36, 1] as const;
 const sidebarExitEase = [0.4, 0, 1, 1] as const;
@@ -193,6 +197,9 @@ export function Sidebar() {
 
   // True while the rename API call is in-flight
   const [isRenamingSaving, setIsRenamingSaving] = useState(false);
+  const [sharingScheduleId, setSharingScheduleId] = useState<string | null>(
+    null,
+  );
 
   // Track which schedule is being deleted (for AlertDialog)
   const [deletingScheduleId, setDeletingScheduleId] = useState<string | null>(
@@ -406,6 +413,83 @@ export function Sidebar() {
   const cancelRenaming = () => {
     setRenamingScheduleId(null);
     setRenameValue("");
+  };
+
+  const getPublicScheduleUrl = (scheduleId: string) => {
+    if (typeof window === "undefined") return `/s/${scheduleId}`;
+    return `${window.location.origin}/s/${scheduleId}`;
+  };
+
+  const copyPublicScheduleLink = async (schedule: Schedule) => {
+    try {
+      await navigator.clipboard.writeText(getPublicScheduleUrl(schedule.id));
+      toast.success("Share link copied", {
+        style: toastStyle,
+        duration: 2000,
+        icon: <Copy className="h-5 w-5 text-green-500" />,
+      });
+    } catch (error) {
+      console.error("Error copying share link:", error);
+      toast.error("Failed to copy share link", {
+        style: toastStyle,
+        icon: <AlertCircle className="h-5 w-5 text-red-500" />,
+      });
+    }
+  };
+
+  const handleToggleShare = async (schedule: Schedule, isPublic: boolean) => {
+    if (!session?.access_token) {
+      toast.error("You must be logged in to share schedules", {
+        style: toastStyle,
+        icon: <AlertCircle className="h-5 w-5 text-red-500" />,
+      });
+      return;
+    }
+
+    setSharingScheduleId(schedule.id);
+    try {
+      const res = await fetch("/api/shareSchedule", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ scheduleId: schedule.id, isPublic }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to update sharing");
+      }
+
+      const updatedSchedule = {
+        ...schedule,
+        isPublic: data.isPublic,
+      };
+      updateScheduleInList(schedule.id, updatedSchedule);
+
+      toast.success(
+        data.isPublic
+          ? "Schedule sharing enabled"
+          : "Schedule sharing disabled",
+        {
+          style: toastStyle,
+          duration: 2000,
+          icon: <Share2 className="h-5 w-5 text-green-500" />,
+        },
+      );
+    } catch (err: unknown) {
+      console.error("Error updating schedule sharing:", err);
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update sharing",
+        {
+          style: toastStyle,
+          icon: <AlertCircle className="h-5 w-5 text-red-500" />,
+        },
+      );
+    } finally {
+      setSharingScheduleId(null);
+    }
   };
 
   /**
@@ -687,9 +771,58 @@ export function Sidebar() {
                                           setMobileMenuOpen(false);
                                         }}
                                       >
-                                        {schedule.name}
+                                        <span className="flex min-w-0 items-center gap-1.5">
+                                          <span className="truncate">
+                                            {schedule.name}
+                                          </span>
+                                          {schedule.isPublic && (
+                                            <LinkIcon className="h-3.5 w-3.5 shrink-0 text-green-400" />
+                                          )}
+                                        </span>
                                       </button>
                                       <div className="flex items-center gap-1 pr-2">
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            handleToggleShare(
+                                              schedule,
+                                              !schedule.isPublic,
+                                            )
+                                          }
+                                          disabled={
+                                            sharingScheduleId === schedule.id
+                                          }
+                                          className="p-1.5 hover:bg-[#555] rounded transition cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+                                          title={
+                                            schedule.isPublic
+                                              ? "Disable sharing"
+                                              : "Enable sharing"
+                                          }
+                                        >
+                                          {sharingScheduleId === schedule.id ? (
+                                            <Loader2 className="h-4 w-4 text-gray-400 animate-spin" />
+                                          ) : (
+                                            <Share2
+                                              className={`h-4 w-4 ${
+                                                schedule.isPublic
+                                                  ? "text-green-400"
+                                                  : "text-gray-400"
+                                              }`}
+                                            />
+                                          )}
+                                        </button>
+                                        {schedule.isPublic && (
+                                          <button
+                                            type="button"
+                                            onClick={() =>
+                                              copyPublicScheduleLink(schedule)
+                                            }
+                                            className="p-1.5 hover:bg-[#555] rounded transition cursor-pointer"
+                                            title="Copy share link"
+                                          >
+                                            <Copy className="h-4 w-4 text-gray-400" />
+                                          </button>
+                                        )}
                                         <button
                                           type="button"
                                           onClick={() =>
@@ -931,7 +1064,14 @@ export function Sidebar() {
                                               console.log(activeSchedule);
                                             }}
                                           >
-                                            {schedule.name}
+                                            <span className="flex min-w-0 items-center gap-1.5">
+                                              <span className="truncate">
+                                                {schedule.name}
+                                              </span>
+                                              {schedule.isPublic && (
+                                                <LinkIcon className="h-3.5 w-3.5 shrink-0 text-green-400" />
+                                              )}
+                                            </span>
                                           </button>
                                           {hoveredScheduleId ===
                                             schedule.id && (
@@ -946,6 +1086,45 @@ export function Sidebar() {
                                               </PopoverTrigger>
                                               <PopoverContent className="bg-[#2a2a2a] border rounded-md border-[#404040] p-2 w-fit">
                                                 <div className="flex flex-col items-start justify-between gap-1 text-sm">
+                                                  <div className="flex w-full items-center justify-between gap-4 rounded-md p-2 font-inter text-white">
+                                                    <span className="flex items-center gap-2">
+                                                      <Share2 className="h-4 w-4" />
+                                                      Share
+                                                    </span>
+                                                    {sharingScheduleId ===
+                                                    schedule.id ? (
+                                                      <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
+                                                    ) : (
+                                                      <Switch
+                                                        checked={Boolean(
+                                                          schedule.isPublic,
+                                                        )}
+                                                        onCheckedChange={(
+                                                          checked,
+                                                        ) =>
+                                                          handleToggleShare(
+                                                            schedule,
+                                                            checked,
+                                                          )
+                                                        }
+                                                      />
+                                                    )}
+                                                  </div>
+                                                  {schedule.isPublic && (
+                                                    <button
+                                                      type="button"
+                                                      className="p-2 rounded-md w-full flex flex-row items-center justify-start gap-2 font-inter cursor-pointer hover:bg-[#444] transition text-white"
+                                                      onClick={() =>
+                                                        copyPublicScheduleLink(
+                                                          schedule,
+                                                        )
+                                                      }
+                                                    >
+                                                      <Copy className="h-4 w-4" />
+                                                      Copy link
+                                                    </button>
+                                                  )}
+                                                  <hr className="w-full border-t border-[#606060]" />
                                                   <button
                                                     type="button"
                                                     className="p-2 rounded-md w-full flex flex-row items-center justify-start gap-2 font-inter cursor-pointer hover:bg-[#444] transition text-white"

--- a/project/bldr/src/lib/scheduleFormat.ts
+++ b/project/bldr/src/lib/scheduleFormat.ts
@@ -1,0 +1,74 @@
+import type { ClassSection } from "@/types";
+
+export type SearchClassMeta = {
+  dept: string;
+  code: string;
+  title: string | null;
+};
+
+export type ClassDetailRow = {
+  uuid: string;
+  classid: number;
+  days: string | null;
+  starttime: string | null;
+  endtime: string | null;
+  component: string | null;
+  instructor: string | null;
+  location: string | null;
+  room: string | null;
+  availseats: number | null;
+  minhours: number | null;
+  maxhours: number | null;
+  searchclass: SearchClassMeta | SearchClassMeta[] | null;
+};
+
+/**
+ * Normalizes Supabase join results because relationship queries can return
+ * either one object or an array depending on generated relationship metadata.
+ */
+export function pickSearchClassMeta(
+  value: SearchClassMeta | SearchClassMeta[] | null,
+): SearchClassMeta {
+  if (Array.isArray(value)) {
+    return value[0] ?? { dept: "", code: "", title: "" };
+  }
+  return value ?? { dept: "", code: "", title: "" };
+}
+
+/**
+ * Returns the best available credit-hour value for UI schedule summaries.
+ */
+export function deriveCreditHours(
+  minhours: number | null,
+  maxhours: number | null,
+) {
+  if (typeof maxhours === "number") return maxhours;
+  if (typeof minhours === "number") return minhours;
+  return undefined;
+}
+
+/**
+ * Converts a database class row into the ClassSection shape used by the UI.
+ */
+export function formatClassSection(row: ClassDetailRow): ClassSection {
+  const course = pickSearchClassMeta(row.searchclass);
+
+  return {
+    uuid: row.uuid,
+    classID: row.classid?.toString() || "",
+    dept: course.dept,
+    code: course.code,
+    title: course.title ?? `${course.dept} ${course.code}`,
+    days: row.days || "",
+    starttime: row.starttime || "",
+    endtime: row.endtime || "",
+    component: row.component || "",
+    instructor: row.instructor || undefined,
+    seats_available: row.availseats ?? 0,
+    minhours: row.minhours ?? undefined,
+    maxhours: row.maxhours ?? undefined,
+    credithours: deriveCreditHours(row.minhours, row.maxhours),
+    location: row.location || undefined,
+    room: row.room || undefined,
+  };
+}

--- a/project/bldr/src/lib/supabase/client.ts
+++ b/project/bldr/src/lib/supabase/client.ts
@@ -1,8 +1,8 @@
-import { createBrowserClient } from '@supabase/ssr';
+import { createBrowserClient } from "@supabase/ssr";
 
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
   );
 }

--- a/project/bldr/src/types/schedule.ts
+++ b/project/bldr/src/types/schedule.ts
@@ -10,6 +10,7 @@ export interface AllSchedulesRecord {
   schedulename: string; // text (NOT NULL)
   semester: string; // character varying (NOT NULL)
   year: number; // integer (NOT NULL, > 1900)
+  is_public: boolean; // boolean (default false)
   createdat?: Date | string; // timestamp (default CURRENT_TIMESTAMP)
   lastedited?: Date | string; // timestamp (default CURRENT_TIMESTAMP)
 }
@@ -42,6 +43,7 @@ export interface Schedule {
   year: number | string; // Can be number from DB or string in UI
   classes: ClassSection[]; // List of class sections in this schedule
   isActive?: boolean; // Maps to isactive from userschedule
+  isPublic?: boolean; // Maps to is_public from allschedules
   createdAt?: Date | string; // Maps to createdat
   updatedAt?: Date | string; // Maps to lastedited
 }

--- a/project/bldr/supabase/migrations/20260423203000_add_public_schedule_sharing.sql
+++ b/project/bldr/supabase/migrations/20260423203000_add_public_schedule_sharing.sql
@@ -1,0 +1,2 @@
+alter table public.allschedules
+add column if not exists is_public boolean not null default false;


### PR DESCRIPTION
## Summary
- add schema support and APIs for public schedule sharing
- add /s/[scheduleId] read-only schedule page
- add sidebar share toggles, shared indicators, and copy-link actions
- preserve existing RLS policies unchanged per request

## Verification
- npx biome check on issue #67 touched TypeScript/TSX files
- npm run build
- manual browser flow confirmed by user after applying migration

Closes #67