### PR TITLE
feat: add click-to-edit jump input for permutation number

### DIFF
--- a/project/bldr/src/components/PermutationBrowser.test.tsx
+++ b/project/bldr/src/components/PermutationBrowser.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for PermutationBrowser
+ *
+ * Verifies the click-to-edit permutation number feature:
+ * 1. Clicking the number reveals a focused input pre-filled with the current 1-based value.
+ * 2. Typing a valid number and pressing Enter calls goToPermutation with the 0-based index.
+ * 3. An out-of-range number is clamped to the nearest valid bound before jumping.
+ * 4. Pressing Escape cancels the edit without calling goToPermutation.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PermutationBrowser from "./PermutationBrowser";
+
+// ─── Mock ScheduleBuilderContext ──────────────────────────────────────────────
+
+const mockGoToPermutation = vi.fn();
+
+const defaultContext = {
+  draftSchedule: [{}], // non-empty so the component renders
+  permutations: Array.from({ length: 10 }, (_, i) => [{ id: i }]), // 10 permutations
+  permutationIndex: 2, // currently showing permutation 3 (1-based)
+  isGeneratingPermutations: false,
+  nextPermutation: vi.fn(),
+  prevPermutation: vi.fn(),
+  goToPermutation: mockGoToPermutation,
+};
+
+vi.mock("@/contexts/ScheduleBuilderContext", () => ({
+  useScheduleBuilder: () => defaultContext,
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PermutationBrowser – click-to-edit permutation number", () => {
+  beforeEach(() => {
+    mockGoToPermutation.mockClear();
+  });
+
+  it("clicking the current number reveals an input pre-filled with the 1-based value", async () => {
+    const user = userEvent.setup();
+    render(<PermutationBrowser />);
+
+    // Initially the number is a button showing "3" (permutationIndex 2 + 1)
+    const jumpBtn = screen.getByRole("button", {
+      name: /jump to a permutation number/i,
+    });
+    expect(jumpBtn).toHaveTextContent("3");
+
+    await user.click(jumpBtn);
+
+    // After click, the input appears with the current value
+    const input = screen.getByRole("textbox", { name: /permutation number/i });
+    expect(input).toBeInTheDocument();
+    expect((input as HTMLInputElement).value).toBe("3");
+  });
+
+  it("pressing Enter commits the typed value as a 0-based index", async () => {
+    const user = userEvent.setup();
+    render(<PermutationBrowser />);
+
+    await user.click(
+      screen.getByRole("button", { name: /jump to a permutation number/i }),
+    );
+
+    const input = screen.getByRole("textbox", { name: /permutation number/i });
+    // Clear pre-filled value, type 5, then press Enter
+    await user.clear(input);
+    await user.type(input, "5");
+    await user.keyboard("{Enter}");
+
+    // 1-based 5 → 0-based 4
+    expect(mockGoToPermutation).toHaveBeenCalledWith(4);
+    // Input is dismissed after commit
+    expect(
+      screen.queryByRole("textbox", { name: /permutation number/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clamps an out-of-range number to the highest valid index", async () => {
+    const user = userEvent.setup();
+    render(<PermutationBrowser />);
+
+    await user.click(
+      screen.getByRole("button", { name: /jump to a permutation number/i }),
+    );
+
+    const input = screen.getByRole("textbox", { name: /permutation number/i });
+    await user.clear(input);
+    await user.type(input, "999");
+    await user.keyboard("{Enter}");
+
+    // Clamped to total (10) → 0-based 9
+    expect(mockGoToPermutation).toHaveBeenCalledWith(9);
+  });
+
+  it("pressing Escape cancels the edit without calling goToPermutation", async () => {
+    const user = userEvent.setup();
+    render(<PermutationBrowser />);
+
+    await user.click(
+      screen.getByRole("button", { name: /jump to a permutation number/i }),
+    );
+
+    // Verify input is open
+    expect(
+      screen.getByRole("textbox", { name: /permutation number/i }),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    // goToPermutation must NOT have been called
+    expect(mockGoToPermutation).not.toHaveBeenCalled();
+    // Input is gone
+    expect(
+      screen.queryByRole("textbox", { name: /permutation number/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/project/bldr/src/components/PermutationBrowser.tsx
+++ b/project/bldr/src/components/PermutationBrowser.tsx
@@ -7,6 +7,7 @@
  * Features:
  * - Left/Right arrows to navigate between permutations
  * - Display of current position (e.g., "3 of 12")
+ * - Click the current number to type and jump to any permutation directly
  * - Loading state while generating permutations
  * - Only visible when there are multiple permutations available
  *
@@ -16,6 +17,7 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { ChevronLeft, ChevronRight, Shuffle } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -42,7 +44,41 @@ export default function PermutationBrowser() {
     isGeneratingPermutations,
     nextPermutation,
     prevPermutation,
+    goToPermutation,
   } = useScheduleBuilder();
+
+  // Local state for the inline edit mode on the permutation number
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus and select the input text whenever edit mode is entered
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  /**
+   * Commit the current input: parse, clamp to [1, total], jump, then exit edit mode.
+   * Invalid/blank input clamps to the current permutation (no-op jump).
+   */
+  const commitEdit = () => {
+    const parsed = Number.parseInt(inputValue, 10);
+    const total = permutations.length;
+    // NaN → treat as current; otherwise clamp to valid 1-based range
+    const oneBased = Number.isNaN(parsed)
+      ? permutationIndex + 1
+      : Math.min(Math.max(parsed, 1), total);
+    goToPermutation(oneBased - 1);
+    setIsEditing(false);
+  };
+
+  const enterEditMode = () => {
+    setInputValue(String(permutationIndex + 1));
+    setIsEditing(true);
+  };
 
   // Don't show if draft is empty
   if (draftSchedule.length === 0) {
@@ -105,9 +141,32 @@ export default function PermutationBrowser() {
         </Button>
 
         <div className="flex items-center gap-0.5 min-w-10 lg:min-w-[50px] justify-center">
-          <span className="text-[10px] lg:text-xs font-dmsans text-white font-medium">
-            {permutationIndex + 1}
-          </span>
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              inputMode="numeric"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitEdit();
+                if (e.key === "Escape") setIsEditing(false);
+              }}
+              onBlur={commitEdit}
+              // Width matches the widest reasonable number so layout stays stable
+              className="w-7 lg:w-8 bg-transparent text-center text-[10px] lg:text-xs font-dmsans text-white font-medium outline-none border-b border-[#A8A8A8] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              aria-label="Permutation number"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={enterEditMode}
+              className="text-[10px] lg:text-xs font-dmsans text-white font-medium hover:underline cursor-pointer"
+              aria-label="Jump to a permutation number"
+            >
+              {permutationIndex + 1}
+            </button>
+          )}
           <span className="text-[9px] lg:text-[10px] text-[#A8A8A8] font-inter">
             /
           </span>


### PR DESCRIPTION
Replaces the static current-permutation number display in PermutationBrowser with a clickable button that opens an inline input. Users can type any number and press Enter (or blur) to jump directly to that permutation; out-of-range values are clamped to [1, total]. Escape cancels without navigating.

Wires the pre-existing but unused goToPermutation() context helper to the UI. No context, type, or API changes required.